### PR TITLE
Fixes to make mammut compile and build a shared library

### DIFF
--- a/demo/task/demo-task.cpp
+++ b/demo/task/demo-task.cpp
@@ -14,7 +14,7 @@ using namespace mammut::task;
 using namespace mammut::topology;
 using namespace std;
 
-static pid_t gettid(){
+pid_t gettid(){
 #ifdef SYS_gettid
     return syscall(SYS_gettid);
 #else

--- a/src/external/odroid-smartpower-linux/Makefile
+++ b/src/external/odroid-smartpower-linux/Makefile
@@ -16,14 +16,14 @@ INCLUDES  = -I ../libusb-1.0.9/
 all: $(OBJS)
 
 $(COBJS): %.o: %.c
-	$(CC) $(CFLAGS) -c $(INCLUDES) $< -o $@
+	$(CC) $(CFLAGS) -c $(INCLUDES) -fPIC $< -o $@
 
 $(CPPOBJS): %.o: %.cpp
-	$(CXX) $(CXXFLAGS) -c $(INCLUDES) $< -o $@
+	$(CXX) $(CXXFLAGS) -c $(INCLUDES) -fPIC $< -o $@
 
 lib: $(OBJS)
 	ar rvs libsmartgauge.a smartgauge.o hid.o
-#	$(CXX) smartgauge.o hid.o -shared -o libsmartgauge.so
+	$(CXX) smartgauge.o hid.o -shared -o libsmartgauge.so
 
 clean:
 	rm -f $(OBJS) 


### PR DESCRIPTION
These small fixes are necessary to build the https://github.com/mathiasbourgoin/ocaml_mammut library.